### PR TITLE
feat: cookie consent popup

### DIFF
--- a/src/layout/PageWithHeaderAndFooter.tsx
+++ b/src/layout/PageWithHeaderAndFooter.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { DivProps } from '../button/Button'
+import { CookieConsent } from '../template/CookieConsent'
 import { Footer } from '../template/Footer'
 import NavBar from '../template/NavBar'
 
@@ -10,6 +11,7 @@ const PageWithHeaderAndFooter = ({ children }: PageWithHeaderAndFooterProps) => 
     <>
       <NavBar />
       <div className="mt-20">{children}</div>
+      <CookieConsent />
       <Footer />
     </>
   )

--- a/src/template/Base.tsx
+++ b/src/template/Base.tsx
@@ -9,6 +9,7 @@ import Subscribe from './Subscribe'
 import UseCases from './UseCases'
 import Demo from './Demo'
 import Reviews from './Reviews'
+import { CookieConsent } from './CookieConsent'
 
 const Base = () => (
   <div className="antialiased text-gray-600">
@@ -20,6 +21,7 @@ const Base = () => (
     <Reviews />
     <CTAGitHub />
     <Subscribe />
+    <CookieConsent />
     <Footer />
   </div>
 )

--- a/src/template/CookieConsent.tsx
+++ b/src/template/CookieConsent.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Button } from '../button/Button'
+import { useCookiePreferences } from '../utils/cookies'
+import { websiteCopyStrings } from '../utils/websiteCopyStrings'
+
+export const CookieConsent = () => {
+  const { prefs, acceptCookies, declineCookies } = useCookiePreferences()
+  if (!prefs || prefs.status !== null) return null
+  return (
+    <div className="cookies-container">
+      {websiteCopyStrings.cookieConsentText}
+      <div className="text-right pt-6">
+        <Button
+          fullRounded
+          className="rounded-full w-48 p-2 inline-block bg-white"
+          onClick={declineCookies}
+        >
+          Decline
+        </Button>{' '}
+        <Button
+          fullRounded
+          secondary
+          className="rounded-full w-48 p-2 mt-2 inline-block"
+          onClick={acceptCookies}
+        >
+          Accept
+        </Button>
+      </div>
+      <style jsx>
+        {`
+          .cookies-container {
+            @apply fixed rounded-lg right-0 bottom-0 m-5 bg-whitesmoke-500 shadow-xl p-8 max-w-2xl;
+            z-index: 101;
+          }
+        `}
+      </style>
+    </div>
+  )
+}

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+
+const COOKIE_STORAGE_KEY = 'jina-cookie-preferences'
+const STATUS_ACCEPTED = 'accepted'
+const STATUS_DECLINED = 'declined'
+
+type CookiePreferences = {
+  status: typeof STATUS_ACCEPTED | typeof STATUS_DECLINED | null;
+};
+
+const defaultCookiePreferences: CookiePreferences = {
+  status: null
+}
+
+export function getCookiePreferenceFromLocalStorage (): CookiePreferences {
+  const prefs = localStorage.getItem(COOKIE_STORAGE_KEY)
+  return prefs ? JSON.parse(prefs) : defaultCookiePreferences
+}
+
+export function setCookiePreferencesInLocalStorage (prefs: CookiePreferences) {
+  localStorage.setItem(COOKIE_STORAGE_KEY, JSON.stringify(prefs))
+}
+
+export function useCookiePreferences () {
+  const [prefs, setPrefs] = useState<CookiePreferences | undefined>()
+
+  useEffect(() => {
+    setPrefs(getCookiePreferenceFromLocalStorage())
+  }, [])
+
+  function updatePrefs (prefs: Partial<CookiePreferences>) {
+    setPrefs((prev) => {
+      if (!prev) return prev
+      const newPrefs: CookiePreferences = {
+        ...prev,
+        ...prefs
+      }
+      setCookiePreferencesInLocalStorage(newPrefs)
+      return newPrefs
+    })
+  }
+
+  function acceptCookies () {
+    updatePrefs({ status: STATUS_ACCEPTED })
+  }
+
+  function declineCookies () {
+    updatePrefs({ status: STATUS_DECLINED })
+  }
+
+  return { prefs, acceptCookies, declineCookies }
+}

--- a/src/utils/websiteCopyStrings.ts
+++ b/src/utils/websiteCopyStrings.ts
@@ -40,6 +40,8 @@ export const websiteCopyStrings = {
   careersWorkingWithUsLanguagesAmount: '12+',
   careersWorkingWithUsTechnologiesTitle: 'Technoloies',
   careersWorkingWithUsTechnologiesAmount: '20+',
+  cookieConsentText:
+    'On our website, we only collect and store information that is essential for offering our service and for improving user experience, and we do this with the consent of our website visitors.',
   navBarHome: 'Home',
   navBarProducts: 'Products',
   navBarDeveloper: 'Developer',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -69,6 +69,9 @@ module.exports = {
         },
         blue: {
           500: '#4DADF7'
+        },
+        whitesmoke: {
+          500: '#F9F5F1'
         }
       },
       lineHeight: {


### PR DESCRIPTION
- Added Cookie Popup, display in `<Base/>` and `<PageWithHeaderAndFooter/>`.
- Expandable `CookiePreferences` interface for adding other detailed settings in the future if we want
- functions and hook to get cookie preferences for use other places (like skipping Google Analytics if user declined)